### PR TITLE
fix(C#): 将URL中的`#`转义为`%23`以正确加载封面

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -270,7 +270,7 @@
 <details>
 <summary>C#</summary>
 
-| <img src="images/编程语言/C#/C＃图解教程  (第5版).jpg" width="150px" /> | <img src="images/编程语言/C#/深入理解C＃（第3版）.jpg" width="150px" /> |
+| <img src="images/编程语言/C%23/C＃图解教程  (第5版).jpg" width="150px" /> | <img src="images/编程语言/C%23/深入理解C＃（第3版）.jpg" width="150px" /> |
 | --------------------- | --------------------- |
 | C＃图解教程  (第<br>5版) | 深入理解C＃（第3版<br>） |
 </details>


### PR DESCRIPTION
注意到URL中半角`#`代表锚点，需要转义为`%23`。图片名使用的是全角的`＃`则没有这个问题。
![image](https://github.com/user-attachments/assets/1b2b596a-51b9-4c6c-af87-a8d965816a2d)
